### PR TITLE
Add unique_id and fix params in create verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ test/dummy/tmp/
 examples/example.csv
 .rspec-failures
 spec/decidim_dummy_app
-
+.byebug_history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 = CHANGELOG
 
+== 0.0.11 PATCH (2023-01-24)
+- Fix params in create action in AuthorizationsController because last upgrade changes was missing.
+- Add the unique_id method to handler to avoid conflicts with others verificators.
+- Minor changes to README and .gitignore
+
 == 0.0.10 PATCH (2022-03-01)
 - Upgrade to Decidim v0.25.2
 - Bump Ruby to v2.7.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decidim-verifications-csv_email (0.0.10)
+    decidim-verifications-csv_email (0.0.11)
       decidim (>= 0.25.2)
       decidim-admin (>= 0.25.2)
       decidim-verifications (>= 0.25.2)

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Create a dummy app in your application (if not present):
 bin/rails decidim:generate_external_test_app
 # Copy migration into spec/decidim_dummy_app/db/migrate
 cd spec/decidim_dummy_app/
-bundle exec rails decidim-verifications-csv_email:install:migrations
+bundle exec rails decidim_verifications_csv_email:install:migrations
 RAILS_ENV=test bundle exec rails db:migrate
 cd ../..
 ```

--- a/app/commands/decidim/verifications/csv_email/confirm_csv_email_user_authorization.rb
+++ b/app/commands/decidim/verifications/csv_email/confirm_csv_email_user_authorization.rb
@@ -8,6 +8,7 @@ module Decidim
           return broadcast(:invalid) unless form.valid?
 
           if confirmation_successful?
+            authorization.unique_id = form.unique_id
             authorization.grant!
             broadcast(:ok)
           else

--- a/app/controllers/decidim/verifications/csv_email/authorizations_controller.rb
+++ b/app/controllers/decidim/verifications/csv_email/authorizations_controller.rb
@@ -14,7 +14,7 @@ module Decidim
 
         def create
           @form = CsvEmailForm.from_params(params.merge(user: current_user))
-          ConfirmCsvEmailUserAuthorization.call(@authorization, @form) do
+          ConfirmCsvEmailUserAuthorization.call(@authorization, @form, session) do
             on(:ok) do
               flash[:notice] = t("authorizations.create.success", scope: "decidim.verifications.csv_email")
               redirect_to decidim_verifications.authorizations_path

--- a/app/forms/decidim/verifications/csv_email/csv_email_form.rb
+++ b/app/forms/decidim/verifications/csv_email/csv_email_form.rb
@@ -14,6 +14,12 @@ module Decidim
         validates :email, presence: true
         validate :censed
 
+        def unique_id
+          Digest::SHA256.hexdigest(
+            "#{user&.decidim_organization_id}-#{user.email}-#{handler_name}-#{Rails.application.secrets.secret_key_base}"
+          )
+        end
+
         # Checks if the email belongs to the census
         def censed
           return if (email == user.email) && (census_for_user&.email == email)

--- a/lib/decidim/verifications/csv_email/version.rb
+++ b/lib/decidim/verifications/csv_email/version.rb
@@ -5,7 +5,7 @@ module Decidim
   module Verifications
     module CsvEmail
       def self.version
-        "0.0.10"
+        "0.0.11"
       end
 
       def self.decidim_version

--- a/spec/forms/decidim/verifications/csv_email/csv_email_form_spec.rb
+++ b/spec/forms/decidim/verifications/csv_email/csv_email_form_spec.rb
@@ -12,7 +12,7 @@ module Decidim
         let(:random_email) { "#{Time.current.to_i}@example.org" }
         let(:attributes) do
           {
-            email: email,
+            email: user.email,
             user: user,
           }
         end
@@ -41,6 +41,17 @@ module Decidim
           let(:email) { "aaa.cccc" }
 
           it { is_expected.not_to be_valid }
+        end
+
+        context "unique_id is generated correctly" do
+          let(:handler_name) { "csv_email_form" }
+          let!(:unique_id) {
+            Digest::SHA256.hexdigest(
+              "#{user&.decidim_organization_id}-#{user.email}-#{handler_name}-#{Rails.application.secrets.secret_key_base}"
+            )
+          }
+
+          it { expect(unique_id).to eq(form.unique_id) }
         end
       end
     end


### PR DESCRIPTION
- Fix params in create action in AuthorizationsController because last upgrade changes was missing.
- Add the unique_id method to handler to avoid conflicts with others verificators.
- Minor changes to README and .gitignore
- New version 0.0.11