### PR TITLE
Update README to use https when installing the gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It has an admin controller to upload CSV files with the information. When import
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'decidim-verifications-csv_email', git: 'git@github.com:CodiTramuntana/decidim-verifications-csv_emails.git'
+gem 'decidim-verifications-csv_email', git: 'https://github.com/CodiTramuntana/decidim-verifications-csv_emails.git'
 ```
 
 And then execute:


### PR DESCRIPTION
Change ssh way to http in README to install gem in other projects.

Issue related: https://github.com/CodiTramuntana/decidim-verifications-csv_emails/issues/18